### PR TITLE
Support getters and setters

### DIFF
--- a/__contracts__/contract-base.test.js
+++ b/__contracts__/contract-base.test.js
@@ -1516,7 +1516,7 @@ assert.throws(
     const CTC1 = CT.CTInstance(
       "C",
       {},
-      {f : { contract : CT.CTFunction(CT.anyCT,[],CT.isNumber)} },
+      {f : { contract : CT.isNumber }},
       C);
     const o = CTC1.wrap(new C()).f;
   },

--- a/__contracts__/contract-base.test.js
+++ b/__contracts__/contract-base.test.js
@@ -1367,7 +1367,7 @@ assert.ok(
 
 	return true;
     })(),
-  "ctinstance.10"
+  "ctinstance.10a"
 );
 
 assert.throws(
@@ -1483,7 +1483,7 @@ assert.throws(
 	return true;
     },
   /blaming: neg/,
-  "ctinstance.10"
+  "ctinstance.10b"
 )
 
 assert.throws(
@@ -1495,7 +1495,7 @@ assert.throws(
     const o = CTC2.wrap(new D());
   },
   /with own property g/,
-  "ctinstance.11"
+  "ctinstance.11a"
 );
 
 assert.throws(
@@ -1507,7 +1507,76 @@ assert.throws(
     const o = CTC2.wrap(new C());
   },
   /that is an instanceof "class D/,
-  "ctinstance.11"
+  "ctinstance.11b"
+);
+
+assert.throws(
+  () => {
+    class C { f; constructor() { this.f = "one"; } }
+    const CTC1 = CT.CTInstance(
+      "C",
+      {},
+      {f : { contract : CT.CTFunction(CT.anyCT,[],CT.isNumber)} },
+      C);
+    const o = CTC1.wrap(new C()).f;
+  },
+  /blaming: pos/,
+  "ctinstance.12"
+);
+
+assert.ok(
+  (() => {
+    class C {
+      get f1() { return 5; }
+      set f2(nv) { }
+    }
+    const ctc = CT.CTInstance(
+      "C",
+      {},
+      {f1 : { contract : CT.isNumber, getter: true },
+       f2 : { contract : CT.isNumber, setter: true }},
+      C);
+    const o = ctc.wrap(new C())
+    o.f2=1;
+    return o.f1 == 5;
+  })(),
+  "ctinstance.13"
+);
+
+assert.throws(
+  () => {
+    class C {
+      get f1() { return "five"; }
+      set f2(nv) { }
+    }
+    const ctc = CT.CTInstance(
+      "C",
+      {},
+      {f1 : { contract : CT.CTFunction(CT.anyCT,[],CT.isNumber), getter: true },
+       f2 : { contract : CT.CTFunction(CT.anyCT,[],CT.isNumber), setter: true }},
+      C);
+    const o = ctc.wrap(new C()).f1
+  },
+  /blaming: pos/,
+  "ctinstance.14"
+);
+
+assert.throws(
+  () => {
+    class C {
+      get f1() { return "five"; }
+      set f2(nv) { }
+    }
+    const ctc = CT.CTInstance(
+      "C",
+      {},
+      {f1 : { contract : CT.isNumber, getter: true },
+       f2 : { contract : CT.isNumber, setter: true }},
+      C);
+    const o = ctc.wrap(new C()).f2="six";
+  },
+  /blaming: neg/,
+  "ctinstance.15"
 );
 
 /*---------------------------------------------------------------------*/


### PR DESCRIPTION
This isn't ready to merge yet. The code generated for the contracts for getters and setters isn't right yet.

It appears that, when Babel parses a typescript file with a getter and setter in it, eg like this:

```
declare class HDNode {
  ...
  get publicExtendedKey(): string;
}
```

then the getter comes out as a `TSDeclareMethod` with a function type (a function that takes no arguments and returns the type of the field), at least that's how they show up to the `accumulateType` function in `compiler.ts`.

The contract system, however, wants to just know the type of the field because the way it is using proxies [here](https://github.com/joshuaharry/scotty/blob/main/__contracts__/contract-base.js#L1115-L1254), the `get` method is called with the field's actual value.

So something has to be adjusted to bridge this gap.